### PR TITLE
Add B2B support for Ratepay

### DIFF
--- a/src/Concardis/Payengine/Lib/Internal/Constants/CustomerType.php
+++ b/src/Concardis/Payengine/Lib/Internal/Constants/CustomerType.php
@@ -2,7 +2,6 @@
 
 namespace Concardis\Payengine\Lib\Internal\Constants;
 
-
 class CustomerType
 {
     const ORGANIZATION = "organization";

--- a/src/Concardis/Payengine/Lib/Internal/Constants/CustomerType.php
+++ b/src/Concardis/Payengine/Lib/Internal/Constants/CustomerType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Concardis\Payengine\Lib\Internal\Constants;
+
+
+class CustomerType
+{
+    const ORGANIZATION = "organization";
+}

--- a/src/Concardis/Payengine/Lib/Internal/Constants/ThreeDsAuthenticationStatus.php
+++ b/src/Concardis/Payengine/Lib/Internal/Constants/ThreeDsAuthenticationStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Concardis\Payengine\Lib\Internal\Constants;
+
+
+/**
+ * Indicates whether a transaction qualifies as an authenticated transaction or account verification.
+ *
+ * @see https://docs.payengine.de/3dsecure/3dsecure_v2_notifications
+ */
+class ThreeDsAuthenticationStatus
+{
+    /**
+     * Y = authentication successful
+     */
+    const AUTHENTICATION_SUCCESSFUL = 'Y';
+
+    /**
+     * N = not authenticated; transaction denied
+     */
+    const AUTHENTICATION_DENIED = 'N';
+
+    /**
+     * U = authentication could not be performed; technical or other problem
+     */
+    const AUTHENTICATION_FAILED = 'U';
+
+    /**
+     * A = attempts processing performed; not attempted
+     */
+    const AUTHENTICATION_ATTEMPTED = 'A';
+
+    /**
+     * R = authentication rejected; issuer is rejecting
+     */
+    const AUTHENTICATION_REJECTED = 'R';
+}

--- a/src/Concardis/Payengine/Lib/Internal/Constants/ThreeDsAuthenticationStatus.php
+++ b/src/Concardis/Payengine/Lib/Internal/Constants/ThreeDsAuthenticationStatus.php
@@ -2,7 +2,6 @@
 
 namespace Concardis\Payengine\Lib\Internal\Constants;
 
-
 /**
  * Indicates whether a transaction qualifies as an authenticated transaction or account verification.
  *

--- a/src/Concardis/Payengine/Lib/Models/Request/Customer.php
+++ b/src/Concardis/Payengine/Lib/Models/Request/Customer.php
@@ -24,28 +24,28 @@ class Customer extends AbstractModel
     /**
      * required for b2b: official name of the organization
      *
-     * @var string
+     * @var string|null
      */
     private $companyName;
 
     /**
      * required for b2b: when customer is an organization, this parameter has one possible value: 'organization'
      *
-     * @var string
+     * @var string|null
      */
     private $customerType;
 
     /**
      * optional for b2b: unique VAT ID number of the organization
      *
-     * @var string
+     * @var string|null
      */
     private $organizationVatId;
 
     /**
      * @return string
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->email;
     }
@@ -53,7 +53,7 @@ class Customer extends AbstractModel
     /**
      * @param string $email
      */
-    public function setEmail($email)
+    public function setEmail(string $email): void
     {
         $this->email = $email;
     }
@@ -61,7 +61,7 @@ class Customer extends AbstractModel
     /**
      * @return string
      */
-    public function getMerchantCustomerId()
+    public function getMerchantCustomerId(): string
     {
         return $this->merchantCustomerId;
     }
@@ -69,55 +69,55 @@ class Customer extends AbstractModel
     /**
      * @param string $merchantCustomerId
      */
-    public function setMerchantCustomerId($merchantCustomerId)
+    public function setMerchantCustomerId(string $merchantCustomerId): void
     {
         $this->merchantCustomerId = $merchantCustomerId;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCompanyName(): string
+    public function getCompanyName(): ?string
     {
         return $this->companyName;
     }
 
     /**
-     * @param string $companyName
+     * @param string|null $companyName
      */
-    public function setCompanyName(string $companyName): void
+    public function setCompanyName(?string $companyName): void
     {
         $this->companyName = $companyName;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCustomerType(): string
+    public function getCustomerType(): ?string
     {
         return $this->customerType;
     }
 
     /**
-     * @param string $customerType
+     * @param string|null $customerType
      */
-    public function setCustomerType(string $customerType): void
+    public function setCustomerType(?string $customerType): void
     {
         $this->customerType = $customerType;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getOrganizationVatId(): string
+    public function getOrganizationVatId(): ?string
     {
         return $this->organizationVatId;
     }
 
     /**
-     * @param string $organizationVatId
+     * @param string|null $organizationVatId
      */
-    public function setOrganizationVatId(string $organizationVatId): void
+    public function setOrganizationVatId(?string $organizationVatId): void
     {
         $this->organizationVatId = $organizationVatId;
     }

--- a/src/Concardis/Payengine/Lib/Models/Request/Customer.php
+++ b/src/Concardis/Payengine/Lib/Models/Request/Customer.php
@@ -45,7 +45,7 @@ class Customer extends AbstractModel
     /**
      * @return string
      */
-    public function getEmail(): string
+    public function getEmail()
     {
         return $this->email;
     }
@@ -53,7 +53,7 @@ class Customer extends AbstractModel
     /**
      * @param string $email
      */
-    public function setEmail(string $email): void
+    public function setEmail($email)
     {
         $this->email = $email;
     }
@@ -61,7 +61,7 @@ class Customer extends AbstractModel
     /**
      * @return string
      */
-    public function getMerchantCustomerId(): string
+    public function getMerchantCustomerId()
     {
         return $this->merchantCustomerId;
     }
@@ -69,7 +69,7 @@ class Customer extends AbstractModel
     /**
      * @param string $merchantCustomerId
      */
-    public function setMerchantCustomerId(string $merchantCustomerId): void
+    public function setMerchantCustomerId($merchantCustomerId)
     {
         $this->merchantCustomerId = $merchantCustomerId;
     }
@@ -77,7 +77,7 @@ class Customer extends AbstractModel
     /**
      * @return string|null
      */
-    public function getCompanyName(): ?string
+    public function getCompanyName()
     {
         return $this->companyName;
     }
@@ -85,7 +85,7 @@ class Customer extends AbstractModel
     /**
      * @param string|null $companyName
      */
-    public function setCompanyName(?string $companyName): void
+    public function setCompanyName($companyName)
     {
         $this->companyName = $companyName;
     }
@@ -93,7 +93,7 @@ class Customer extends AbstractModel
     /**
      * @return string|null
      */
-    public function getCustomerType(): ?string
+    public function getCustomerType()
     {
         return $this->customerType;
     }
@@ -101,7 +101,7 @@ class Customer extends AbstractModel
     /**
      * @param string|null $customerType
      */
-    public function setCustomerType(?string $customerType): void
+    public function setCustomerType($customerType)
     {
         $this->customerType = $customerType;
     }
@@ -109,7 +109,7 @@ class Customer extends AbstractModel
     /**
      * @return string|null
      */
-    public function getOrganizationVatId(): ?string
+    public function getOrganizationVatId()
     {
         return $this->organizationVatId;
     }
@@ -117,7 +117,7 @@ class Customer extends AbstractModel
     /**
      * @param string|null $organizationVatId
      */
-    public function setOrganizationVatId(?string $organizationVatId): void
+    public function setOrganizationVatId($organizationVatId)
     {
         $this->organizationVatId = $organizationVatId;
     }

--- a/src/Concardis/Payengine/Lib/Models/Request/Customer.php
+++ b/src/Concardis/Payengine/Lib/Models/Request/Customer.php
@@ -36,6 +36,13 @@ class Customer extends AbstractModel
     private $customerType;
 
     /**
+     * optional for b2b: unique VAT ID number of the organization
+     *
+     * @var string
+     */
+    private $organizationVatId;
+
+    /**
      * @return string
      */
     public function getEmail()
@@ -99,4 +106,19 @@ class Customer extends AbstractModel
         $this->customerType = $customerType;
     }
 
+    /**
+     * @return string
+     */
+    public function getOrganizationVatId(): string
+    {
+        return $this->organizationVatId;
+    }
+
+    /**
+     * @param string $organizationVatId
+     */
+    public function setOrganizationVatId(string $organizationVatId): void
+    {
+        $this->organizationVatId = $organizationVatId;
+    }
 }

--- a/src/Concardis/Payengine/Lib/Models/Request/Customer.php
+++ b/src/Concardis/Payengine/Lib/Models/Request/Customer.php
@@ -2,7 +2,6 @@
 
 namespace Concardis\Payengine\Lib\Models\Request;
 
-
 use Concardis\Payengine\Lib\Internal\AbstractClass\AbstractModel;
 
 class Customer extends AbstractModel

--- a/src/Concardis/Payengine/Lib/Models/Request/Customer.php
+++ b/src/Concardis/Payengine/Lib/Models/Request/Customer.php
@@ -9,15 +9,31 @@ class Customer extends AbstractModel
 {
     /**
      * Email of the customer
+     *
      * @var string
      */
     private $email;
 
     /**
      * Id for this customer on your System
+     *
      * @var string
      */
     private $merchantCustomerId;
+
+    /**
+     * required for b2b: official name of the organization
+     *
+     * @var string
+     */
+    private $companyName;
+
+    /**
+     * required for b2b: when customer is an organization, this parameter has one possible value: 'organization'
+     *
+     * @var string
+     */
+    private $customerType;
 
     /**
      * @return string
@@ -49,6 +65,38 @@ class Customer extends AbstractModel
     public function setMerchantCustomerId($merchantCustomerId)
     {
         $this->merchantCustomerId = $merchantCustomerId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCompanyName(): string
+    {
+        return $this->companyName;
+    }
+
+    /**
+     * @param string $companyName
+     */
+    public function setCompanyName(string $companyName): void
+    {
+        $this->companyName = $companyName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomerType(): string
+    {
+        return $this->customerType;
+    }
+
+    /**
+     * @param string $customerType
+     */
+    public function setCustomerType(string $customerType): void
+    {
+        $this->customerType = $customerType;
     }
 
 }


### PR DESCRIPTION
For B2B support of Ratepay payment methods, new fields need to be integrated in the Customer class (companyName, customerType & organizationVatId). Furthermore, for the credit card payment method, constants regarding the 3DS authentication status have been outsourced. 